### PR TITLE
prose: Ensure symbols remain aligned in code blocks

### DIFF
--- a/src/components/controls/Prose.astro
+++ b/src/components/controls/Prose.astro
@@ -7,7 +7,9 @@
     prose-a:text-blue-300 prose-a:no-underline prose-a:font-normal
     hover:prose-a:text-blue-400 hover:prose-a:underline
     prose-inline-code:text-orange-500 prose-inline-code:font-code prose-inline-code:text-sm
-    prose-pre:text-xs prose-code:text-nowrap sm:prose-pre:text-sm"
+    prose-pre:text-xs prose-code:text-nowrap sm:prose-pre:text-sm
+    prose-pre:font-code prose-code:font-code
+    prose-pre:eaw-prop prose-code:eaw-prop"
 >
   <slot />
 </div>

--- a/src/layouts/Root.astro
+++ b/src/layouts/Root.astro
@@ -43,6 +43,9 @@ const siteName = "Isaac Corbrey";
 			rel="stylesheet"
 		/>
 
+		<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/mshaugh/nerdfont-webfonts@v3.3.0/build/firacode-nerd-font.css">
+ 
 		<title>{[props.title, siteName].filter(Boolean).join(" - ")}</title>
 
 		<meta property="og:url" content={props.path} />

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -4,7 +4,7 @@ export default {
 	theme: {
 		fontFamily: {
 			display: ['"Afacad Flux"', 'sans-serif'],
-			code: ['"Fira Code"', 'monospace'],
+			code: ['"FiraCode Nerd Font"', '"Fira Code"', 'monospace'],
 		},
 		extend: {
 			colors: {


### PR DESCRIPTION
I was running into an issue where certain symbols (specifically ◆ in this case) were taking up more width than they should have in code blocks. This was because the glyph wasn't provided by Fira Code, so it was falling back to Segoe UI Symbol. I've imported the Fira Code nerd font to fix this.