### PR TITLE
notes: Comply with Stripe's content policy

### DIFF
--- a/src/components/notes/NotePage.astro
+++ b/src/components/notes/NotePage.astro
@@ -64,8 +64,8 @@ function joinReviewers(nodes: any[]) {
         <p>
           I like building tools, breaking workflows, and putting them back together
           better. If you enjoy my work and want to support it, you can
-          <a href={kofi}>buy me a coffee ☕</a> or <a href={liberapay}>donate via
-          Liberapay 💛</a>.
+          <a href={kofi}>buy me a coffee ☕</a> or <a href={liberapay}>support
+          me on Liberapay 💛</a>.
         </p>
       </Prose>
     </div>


### PR DESCRIPTION
Per [Stripe's requirements], you can't use the word "donate" when accepting money from others unless it's for a specific charitable purpose. We're switching to "support" instead to comply with their policy.

[Stripe's requirements]: https://support.stripe.com/questions/requirements-for-accepting-tips-or-donations